### PR TITLE
Fix for double-newlines in code blocks

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -128,7 +128,7 @@ def optwrap(text):
     newlines = 0
     for para in text.split("\n"):
         if len(para) > 0:
-            if para[0] is not ' ' and para[0] is not '-' and para[0] is not '*':
+            if para[0] != ' ' and para[0] != '-' and para[0] != '*':
                 for line in wrap(para, BODY_WIDTH):
                     result += line + "\n"
                 result += "\n"


### PR DESCRIPTION
I'm not a Python programmer at all, but the string comparisons with `not in` operator didn't seem to work at all.
