### PR TITLE
Google docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+#html2text
+
+Converts html documents to markdown format.
+
+*Handling Google Docs documents is currently work-in-progress.*
+
+#Copyright
+
+Originally written by Aaron Swartz.
+
+#License
+This code is distributed under the GPLv3.

--- a/html2text.py
+++ b/html2text.py
@@ -218,6 +218,7 @@ class _html2text(HTMLParser.HTMLParser):
         self.blockquote = 0
         self.pre = 0
         self.startpre = 0
+        self.br_toggle = ''
         self.lastWasNL = 0
         self.lastWasList = False
         self.style = 0
@@ -280,7 +281,11 @@ class _html2text(HTMLParser.HTMLParser):
             self.p()
             if start: self.o(hn(tag)*"#" + ' ')
 
-        if tag in ['p', 'div']: self.p()
+        if tag in ['p', 'div']:
+            if options.google_doc:
+                self.soft_br()
+            else:
+                self.p()
         
         if tag == "br" and start: self.o("  \n")
 
@@ -431,6 +436,10 @@ class _html2text(HTMLParser.HTMLParser):
         if self.p_p == 0: self.p_p = 1
 
     def p(self): self.p_p = 2
+
+    def soft_br(self):
+        self.pbr()
+        self.br_toggle = '  '
     
     def o(self, data, puredata=0, force=0):
         if self.abbr_data is not None: self.abbr_data += data
@@ -467,8 +476,9 @@ class _html2text(HTMLParser.HTMLParser):
 
 
             if self.p_p:
-                self.out(('\n'+bq)*self.p_p)
+                self.out((self.br_toggle+'\n'+bq)*self.p_p)
                 self.space = 0
+                self.br_toggle = ''
                 
             if self.space:
                 if not self.lastWasNL: self.out(' ')

--- a/html2text.py
+++ b/html2text.py
@@ -51,6 +51,9 @@ SKIP_INTERNAL_LINKS = True
 # Use inline, rather than reference, formatting for images and links
 INLINE_LINKS = True
 
+# Number of pixels Google indents nested lists
+GOOGLE_LIST_INDENT = 36
+
 ### Entity Nonsense ###
 
 def name2cp(k):
@@ -183,7 +186,7 @@ def google_nest_count(attrs, style_def):
     for css_class in attrs['class'].split():
         css_style = style_def['.' + css_class]
         if 'margin-left' in css_style:
-            nest_count = int(css_style['margin-left'][:-2]) / 36
+            nest_count = int(css_style['margin-left'][:-2]) / GOOGLE_LIST_INDENT
     return nest_count
 
 def google_has_height(attrs, style_def):
@@ -552,6 +555,8 @@ if __name__ == "__main__":
         default=False, help="use a dash rather than a star for unordered list items")
     p.add_option("-b", "--body-width", dest="body_width", action="store", type="int",
         default=78, help="number of characters per output line, 0 for no wrap")
+    p.add_option("-i", "--google-list-indent", dest="list_indent", action="store", type="int",
+        default=GOOGLE_LIST_INDENT, help="number of pixels Google indents nested lists")
     (options, args) = p.parse_args()
 
     # handle options
@@ -561,6 +566,7 @@ if __name__ == "__main__":
         options.ul_item_mark = '*'
 
     BODY_WIDTH = options.body_width
+    GOOGLE_LIST_INDENT = options.list_indent
 
     # process input
     if len(args) > 0:

--- a/html2text.py
+++ b/html2text.py
@@ -188,6 +188,18 @@ def google_nest_count(attrs, style_def):
             nest_count = int(css_style['margin-left'][:-2]) / 36
     return nest_count
 
+def google_has_height(attrs, style_def):
+    """calculate the nesting count of google doc lists"""
+    if attrs is None:
+        return False
+    x = dict(attrs)
+    nest_count = 0
+    for css_class in x['class'].split():
+        css_style = style_def['.' + css_class]
+        if 'height' in css_style:
+            return True
+    return False
+
 def list_numbering_start(attrs, style_def):
     """extract numbering from list element attributes"""
     x = dict(attrs)
@@ -283,7 +295,10 @@ class _html2text(HTMLParser.HTMLParser):
 
         if tag in ['p', 'div']:
             if options.google_doc:
-                self.soft_br()
+                if google_has_height(attrs, self.style_def):
+                    self.p()
+                else:
+                    self.soft_br()
             else:
                 self.p()
         

--- a/html2text.py
+++ b/html2text.py
@@ -171,8 +171,7 @@ def dumb_css_parser(data):
 
 def google_list_style(attrs, style_def):
     """finds out whether this is an ordered or unordered list"""
-    x = dict(attrs)
-    for css_class in x['class'].split():
+    for css_class in attrs['class'].split():
         list_style = style_def['.' + css_class]['list-style-type']
         if list_style in ['disc', 'circle', 'square', 'none']:
             return 'ul'
@@ -180,9 +179,8 @@ def google_list_style(attrs, style_def):
 
 def google_nest_count(attrs, style_def):
     """calculate the nesting count of google doc lists"""
-    x = dict(attrs)
     nest_count = 0
-    for css_class in x['class'].split():
+    for css_class in attrs['class'].split():
         css_style = style_def['.' + css_class]
         if 'margin-left' in css_style:
             nest_count = int(css_style['margin-left'][:-2]) / 36
@@ -190,11 +188,10 @@ def google_nest_count(attrs, style_def):
 
 def google_has_height(attrs, style_def):
     """calculate the nesting count of google doc lists"""
-    if attrs is None:
+    if not 'class' in attrs:
         return False
-    x = dict(attrs)
     nest_count = 0
-    for css_class in x['class'].split():
+    for css_class in attrs['class'].split():
         css_style = style_def['.' + css_class]
         if 'height' in css_style:
             return True
@@ -202,9 +199,8 @@ def google_has_height(attrs, style_def):
 
 def list_numbering_start(attrs, style_def):
     """extract numbering from list element attributes"""
-    x = dict(attrs)
-    if 'start' in x:
-        return int(x['start']) - 1
+    if 'start' in attrs:
+        return int(attrs['start']) - 1
     else:
         return 0
 
@@ -288,6 +284,10 @@ class _html2text(HTMLParser.HTMLParser):
 
     def handle_tag(self, tag, attrs, start):
         #attrs = fixattrs(attrs)
+        if attrs is None:
+            attrs = {}
+        else:
+            attrs = dict(attrs)
     
         if hn(tag):
             self.p()
@@ -333,10 +333,6 @@ class _html2text(HTMLParser.HTMLParser):
         if tag == "code" and not self.pre: self.o('`') #TODO: `` `this` ``
         if tag == "abbr":
             if start:
-                attrsD = {}
-                for (x, y) in attrs: attrsD[x] = y
-                attrs = attrsD
-                
                 self.abbr_title = None
                 self.abbr_data = ''
                 if has_key(attrs, 'title'):
@@ -349,9 +345,6 @@ class _html2text(HTMLParser.HTMLParser):
         
         if tag == "a":
             if start:
-                attrsD = {}
-                for (x, y) in attrs: attrsD[x] = y
-                attrs = attrsD
                 if has_key(attrs, 'href') and not (SKIP_INTERNAL_LINKS and attrs['href'].startswith('#')): 
                     self.astack.append(attrs)
                     self.o("[")
@@ -375,9 +368,6 @@ class _html2text(HTMLParser.HTMLParser):
                             self.o("][" + str(a['count']) + "]")
         
         if tag == "img" and start:
-            attrsD = {}
-            for (x, y) in attrs: attrsD[x] = y
-            attrs = attrsD
             if has_key(attrs, 'src'):
                 attrs['href'] = attrs['src']
                 alt = attrs.get('alt', '')

--- a/html2text.py
+++ b/html2text.py
@@ -165,7 +165,7 @@ def google_list_style(attrs, style_def):
     # finds out wether this is an ordered or unordered list
     x = dict(attrs)
     list_style = style_def['.' + x['class']]['list-style-type']
-    if list_style in ['disc', 'circle']:
+    if list_style in ['disc', 'circle', 'square', 'none']:
         return 'ul'
     else:
         return 'ol'
@@ -181,7 +181,7 @@ class _html2text(HTMLParser.HTMLParser):
         except NameError: # Python3
             self.outtext = str()
         self.quiet = 0
-        self.p_p = 0
+        self.p_p = 0 # number of newline character to print before next output
         self.outcount = 0
         self.start = 1
         self.space = 0
@@ -357,6 +357,8 @@ class _html2text(HTMLParser.HTMLParser):
         if tag == 'dd' and not start: self.pbr()
         
         if tag in ["ol", "ul"]:
+            if not self.list:
+                self.p()
             if start:
                 if options.google_doc:
                     list_style = google_list_style(attrs, self.style_def)
@@ -365,12 +367,10 @@ class _html2text(HTMLParser.HTMLParser):
                 self.list.append({'name':list_style, 'num':0})
             else:
                 if self.list: self.list.pop()
-            
-            self.p()
         
         if tag == 'li':
+            self.pbr()
             if start:
-                self.pbr()
                 if self.list: li = self.list[-1]
                 else: li = {'name':'ul', 'num':0}
                 self.o("  "*len(self.list)) #TODO: line up <ol><li>s > 9 correctly.
@@ -379,8 +379,6 @@ class _html2text(HTMLParser.HTMLParser):
                     li['num'] += 1
                     self.o(str(li['num'])+". ")
                 self.start = 1
-            else:
-                self.pbr()
         
         if tag in ["table", "tr"] and start: self.p()
         if tag == 'td': self.pbr()

--- a/html2text.py
+++ b/html2text.py
@@ -374,7 +374,7 @@ class _html2text(HTMLParser.HTMLParser):
                 if self.list: li = self.list[-1]
                 else: li = {'name':'ul', 'num':0}
                 self.o("  "*len(self.list)) #TODO: line up <ol><li>s > 9 correctly.
-                if li['name'] == "ul": self.o("* ")
+                if li['name'] == "ul": self.o("- ")
                 elif li['name'] == "ol":
                     li['num'] += 1
                     self.o(str(li['num'])+". ")

--- a/html2text.py
+++ b/html2text.py
@@ -171,10 +171,18 @@ def google_list_style(attrs, style_def):
         return 'ol'
 
 def google_nest_count(attrs, style_def):
-    # finds out wether this is an ordered or unordered list
+    # calculate the nesting count of google doc lists
     x = dict(attrs)
     nest_count = int(style_def['.' + x['class']]['margin-left'][:-2]) / 36
     return nest_count
+
+def list_numbering_start(attrs, style_def):
+    # extract numbering from list element attributes
+    x = dict(attrs)
+    if 'start' in x:
+        return int(x['start']) - 1
+    else:
+        return 0
 
 class _html2text(HTMLParser.HTMLParser):
     def __init__(self, out=None, baseurl=''):
@@ -372,7 +380,8 @@ class _html2text(HTMLParser.HTMLParser):
                     list_style = google_list_style(attrs, self.style_def)
                 else:
                     list_style = tag
-                self.list.append({'name':list_style, 'num':0})
+                numbering_start = list_numbering_start(attrs, self.style_def)
+                self.list.append({'name':list_style, 'num':numbering_start})
             else:
                 if self.list: self.list.pop()
             self.lastWasList = True

--- a/html2text.py
+++ b/html2text.py
@@ -535,13 +535,19 @@ if __name__ == "__main__":
         default=False, help="convert an html-exported Google Document")
     p.add_option("-d", "--dash-unordered-list", action="store_true", dest="ul_style_dash",
         default=False, help="use a dash rather than a star for unordered list items")
+    p.add_option("-b", "--body-width", dest="body_width", action="store", type="int",
+        default=78, help="number of characters per output line, 0 for no wrap")
     (options, args) = p.parse_args()
 
+    # handle options
     if options.ul_style_dash:
         options.ul_item_mark = '-'
     else:
         options.ul_item_mark = '*'
 
+    BODY_WIDTH = options.body_width
+
+    # process input
     if len(args) > 0:
         file_ = args[0]
         encoding = None

--- a/html2text.py
+++ b/html2text.py
@@ -154,30 +154,42 @@ def hn(tag):
         except ValueError: return 0
 
 def dumb_css_parser(data):
-    # returns a hash of css selectors, each of which contains a hash of css attributes
+    """returns a hash of css selectors, each of which contains a hash of css attributes"""
+    # remove @import sentences
+    importIndex = data.find('@import')
+    while importIndex != -1:
+        data = data[0:importIndex] + data[data.find(';', importIndex) + 1:]
+        importIndex = data.find('@import')
+
+    # parse the css
     elements =  [x.split('{') for x in data.split('}') if x.strip() != '']
     elements = {a.strip() : 
         {x.strip() : y.strip() for x, y in [z.split(':') for z in b.split(';')]} 
         for a, b in elements}
+
     return elements
 
 def google_list_style(attrs, style_def):
-    # finds out wether this is an ordered or unordered list
+    """finds out whether this is an ordered or unordered list"""
     x = dict(attrs)
-    list_style = style_def['.' + x['class']]['list-style-type']
-    if list_style in ['disc', 'circle', 'square', 'none']:
-        return 'ul'
-    else:
-        return 'ol'
+    for css_class in x['class'].split():
+        list_style = style_def['.' + css_class]['list-style-type']
+        if list_style in ['disc', 'circle', 'square', 'none']:
+            return 'ul'
+    return 'ol'
 
 def google_nest_count(attrs, style_def):
-    # calculate the nesting count of google doc lists
+    """calculate the nesting count of google doc lists"""
     x = dict(attrs)
-    nest_count = int(style_def['.' + x['class']]['margin-left'][:-2]) / 36
+    nest_count = 0
+    for css_class in x['class'].split():
+        css_style = style_def['.' + css_class]
+        if 'margin-left' in css_style:
+            nest_count = int(css_style['margin-left'][:-2]) / 36
     return nest_count
 
 def list_numbering_start(attrs, style_def):
-    # extract numbering from list element attributes
+    """extract numbering from list element attributes"""
     x = dict(attrs)
     if 'start' in x:
         return int(x['start']) - 1

--- a/html2text.py
+++ b/html2text.py
@@ -374,7 +374,7 @@ class _html2text(HTMLParser.HTMLParser):
                 if self.list: li = self.list[-1]
                 else: li = {'name':'ul', 'num':0}
                 self.o("  "*len(self.list)) #TODO: line up <ol><li>s > 9 correctly.
-                if li['name'] == "ul": self.o("- ")
+                if li['name'] == "ul": self.o(options.ul_item_mark + " ")
                 elif li['name'] == "ol":
                     li['num'] += 1
                     self.o(str(li['num'])+". ")
@@ -499,7 +499,15 @@ if __name__ == "__main__":
                               version='%prog ' + __version__)
     p.add_option("-g", "--google-doc", action="store_true", dest="google_doc",
         default=False, help="convert an html-exported Google Document")
+    p.add_option("-d", "--dash-unordered-list", action="store_true", dest="ul_style_dash",
+        default=False, help="use a dash rather than a star for unordered list items")
     (options, args) = p.parse_args()
+
+    if options.ul_style_dash:
+        options.ul_item_mark = '-'
+    else:
+        options.ul_item_mark = '*'
+
     if len(args) > 0:
         file_ = args[0]
         encoding = None


### PR DESCRIPTION
I have added the option to convert Google Docs documents, which were exported as HTML, to markdown.

Google uses CSS, rather then pure HTML, to differentiate ordered lists from unordered ones. They employ similar trickery for other components as well, probably in order to gain good cross-browser support. However these tricks make it difficult to convert these documents to text. 

Here I tried to handle Google's peculiarities. The support is not yet complete, but is already pretty usable. All the additional code is protected under command line options.

Please let me know if there is any problem with the code.

Thanks,
Yariv
