### PR TITLE
Google docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Converts html documents to markdown format.
 
-*Handling Google Docs documents is currently work-in-progress.*
-
 #Copyright
 
 Originally written by Aaron Swartz.

--- a/html2text.py
+++ b/html2text.py
@@ -338,24 +338,24 @@ class _html2text(HTMLParser.HTMLParser):
         if start:
             # crossed-out text must be handled before other attributes
             # in order not to output qualifiers unnecessarily
+            if bold or italic or fixed:
+                self.emphasis += 1
             if strikethrough:
                 self.quiet += 1
             if italic:
                 self.o("_")
-                self.emphasis += 1
                 self.drop_white_space += 1
             if bold:
                 self.o("**")
-                self.emphasis += 1
                 self.drop_white_space += 1
             if fixed:
                 self.o('`')
-                self.emphasis += 1
                 self.drop_white_space += 1
                 self.code = True
         else:
             if bold or italic or fixed:
                 # there must not be whitespace before closing emphasis mark
+                self.emphasis -= 1
                 self.space = 0
                 self.outtext = self.outtext.rstrip()
             if fixed:
@@ -365,7 +365,6 @@ class _html2text(HTMLParser.HTMLParser):
                     self.drop_white_space -= 1
                 else:
                     self.o('`')
-                self.emphasis -= 1
                 self.code = False
             if bold:
                 if self.drop_white_space:
@@ -374,7 +373,6 @@ class _html2text(HTMLParser.HTMLParser):
                     self.drop_white_space -= 1
                 else:
                     self.o("**")
-                self.emphasis -= 1
             if italic:
                 if self.drop_white_space:
                     # empty emphasis, drop it
@@ -382,7 +380,6 @@ class _html2text(HTMLParser.HTMLParser):
                     self.drop_white_space -= 1
                 else:
                     self.o("_")
-                self.emphasis -= 1
             # space is only allowed after *all* emphasis marks
             if (bold or italic) and not self.emphasis:
                     self.o(" ")

--- a/html2text.py
+++ b/html2text.py
@@ -356,13 +356,18 @@ class _html2text(HTMLParser.HTMLParser):
         if tag in ['strong', 'b']: self.o("**")
 
         if options.google_doc:
-            # handle Google's bold and italic
+            # handle Google's bold, italic and crossed-out text. assume well-formed html
             if start:
                 self.tag_stack.append((tag, attrs))
             else:
                 dummy, attrs = self.tag_stack.pop()
             if not self.inheader:
                 text_emphasis = google_text_emphasis(attrs, self.style_def)
+                if 'line-through' in text_emphasis and options.hide_strikethrough:
+                    if start:
+                        self.quiet += 1
+                    else:
+                        self.quiet -= 1
                 if 'bold' in text_emphasis:
                     self.o("**")
                 if 'italic' in text_emphasis:
@@ -607,6 +612,8 @@ if __name__ == "__main__":
         default=78, help="number of characters per output line, 0 for no wrap")
     p.add_option("-i", "--google-list-indent", dest="list_indent", action="store", type="int",
         default=GOOGLE_LIST_INDENT, help="number of pixels Google indents nested lists")
+    p.add_option("-s", "--hide-strikethrough", action="store_true", dest="hide_strikethrough",
+        default=False, help="hide strike-through text. only relevent when -g is specified as well")
     (options, args) = p.parse_args()
 
     # handle options

--- a/html2text.py
+++ b/html2text.py
@@ -338,12 +338,13 @@ class _html2text(HTMLParser.HTMLParser):
                 dummy, attrs, tag_style = self.tag_stack.pop()
 
         if hn(tag):
+            self.p()
             if start:
                 self.inheader = True
+                self.o(hn(tag)*"#" + ' ')
             else:
                 self.inheader = False
-            self.p()
-            if start: self.o(hn(tag)*"#" + ' ')
+                return # prevent redundant emphasis marks on headers
 
         if tag in ['p', 'div']:
             if options.google_doc:


### PR DESCRIPTION
This patch fixes several issues that I had with the handling of Google Docs.

Supporting the conversion of Google Docs to Markdown is more or less complete now, at least with regard to simple documents. It is not fully compatible with 'standard' html document, so this functionality is still protected by command line options, and defaults to false (btw sorry about the problem with the options variable).

Note that only 'new style' Google Docs are supported. This should not be a problem as Google offers to convert old-format documents to the new format whenever you open them.

Thanks,
Yariv
