### PR TITLE
very slow string concatenation (self.outtest +=s ) replaced with list app

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -290,7 +290,7 @@ class _html2text(HTMLParser.HTMLParser):
         self.pbr()
         self.o('', 0, 'end')
 
-        self.outtext = self.outtext.join(self.outtestlist)
+        self.outtext = self.outtext.join(self.outtextlist)
         
         if options.google_doc:
             self.outtext = self.outtext.replace('&nbsp_place_holder;', ' ');

--- a/html2text.py
+++ b/html2text.py
@@ -282,7 +282,7 @@ class _html2text(HTMLParser.HTMLParser):
     
     def outtextf(self, s): 
         self.outtextlist.append(s)
-        self.lastWasNL = s[-1] == '\n'
+        if s: self.lastWasNL = s[-1] == '\n'
     
     def close(self):
         HTMLParser.HTMLParser.close(self)

--- a/html2text.py
+++ b/html2text.py
@@ -244,6 +244,7 @@ class _html2text(HTMLParser.HTMLParser):
         
         if out is None: self.out = self.outtextf
         else: self.out = out
+        self.outtextlist = [] # empty list to store output characters before they are  "joined"
         try:
             self.outtext = unicode()
         except NameError: # Python3
@@ -280,8 +281,8 @@ class _html2text(HTMLParser.HTMLParser):
             unifiable['nbsp'] = '&nbsp_place_holder;'
     
     def outtextf(self, s): 
-        self.outtext += s
-        self.lastWasNL = self.outtext[-1] == '\n'
+        self.outtextlist.append(s)
+        self.lastWasNL = s[-1] == '\n'
     
     def close(self):
         HTMLParser.HTMLParser.close(self)
@@ -289,6 +290,8 @@ class _html2text(HTMLParser.HTMLParser):
         self.pbr()
         self.o('', 0, 'end')
 
+        self.outtext = self.outtext.join(self.outtestlist)
+        
         if options.google_doc:
             self.outtext = self.outtext.replace('&nbsp_place_holder;', ' ');
         


### PR DESCRIPTION
very slow string concatenation (self.outtest +=s ) replaced with list append and a final "".join()

Processing a 5MB html file with this was taking ~2500 sconds before this patch. With this patch it only takes ~20 seconds. 
