### PR TITLE
Keep <del> and <strike> tag

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -468,6 +468,11 @@ class _html2text(HTMLParser.HTMLParser):
         
         if tag in ['em', 'i', 'u']: self.o("_")
         if tag in ['strong', 'b']: self.o("**")
+        if tag in ['del', 'strike']:
+            if start:                                                           
+                self.o("<"+tag+">")
+            else:
+                self.o("</"+tag+">")
 
         if options.google_doc:
             if not self.inheader:


### PR DESCRIPTION
I was converting my Wordpress posts to Markdown, and I found that all `<del>` and `<strike>` tags have been removed (only data are kept).

So here comes a patch that outputs `<del>` and `<strike>` tags (but no attributes are kept, since I don't know how to access "tag with angle brackets and attrs").

Would be better if there is an option for whether to keep unknown tags or not.
## 

p.s. I'm not a Python programmer, so I can't help you much further.  I only implemented what I need, and feedback this to you.
