### PR TITLE
Fix handling of empty stripped para in skipwrap

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -721,7 +721,7 @@ def skipwrap(para):
         return False
     # I'm not sure what this is for; I thought it was to detect lists, but there's
     # a <br>-inside-<span> case in one of the tests that also depends upon it.
-    if stripped[0] == '-' or stripped[0] == '*':
+    if stripped[0:1] == '-' or stripped[0:1] == '*':
         return True
     # If the text begins with a single -, *, or +, followed by a space, or an integer,
     # followed by a ., followed by a space (in either case optionally preceeded by


### PR DESCRIPTION
e522f85c refactored handling of paragraphs, but now can crash with
IndexError, if the stripped string is empty.

This patch fixes this by using slice indices.
