### PR TITLE
Fix: Escaping parenthesis in URLs to prevent links and image syntax from breaking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = CRLF
+
+; 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.py[co]
+*.bak
 test/*output.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.py[co]
 *.bak
 test/*output.md
+build
+dist
+*.egg-info

--- a/html2text.py
+++ b/html2text.py
@@ -717,7 +717,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 
 ordered_list_matcher = re.compile(r'\d+\.\s')
 unordered_list_matcher = re.compile(r'[-\*\+]\s')
-md_chars_matcher = re.compile(r"([\\`\*_{}\[\]\(\)#\+-\.!])")
+md_chars_matcher = re.compile(r"([\\\[\]\(\)])")
 
 def skipwrap(para):
     # If the text begins with four spaces or one tab, it's a code block; don't wrap
@@ -757,7 +757,7 @@ def unescape(s, unicode_snob=False):
 
 def escape_md(text):
     """Escapes markdown-sensitive characters."""
-    return md_chars_matcher.sub(r"\1", text)
+    return md_chars_matcher.sub(r"\\\1", text)
 
 def main():
     baseurl = ''

--- a/html2text.py
+++ b/html2text.py
@@ -757,7 +757,7 @@ def unescape(s, unicode_snob=False):
 
 def escape_md(text):
     """Escapes markdown-sensitive characters."""
-    return md_chars_matcher.sub("\\\t", text)
+    return md_chars_matcher.sub(r"\1", text)
 
 def main():
     baseurl = ''

--- a/test/malformed.html
+++ b/test/malformed.html
@@ -1,3 +1,0 @@
-<h1>Malformed HTML input</h1>
-
-<p>Anchors w/o href value: <a href=>1</a>, <a href=''>2</a>, <a href="">3</a>, <a></a></p>

--- a/test/malformed.html
+++ b/test/malformed.html
@@ -1,0 +1,3 @@
+<h1>Malformed HTML input</h1>
+
+<p>Anchors w/o href value: <a href=>1</a>, <a href=''>2</a>, <a href="">3</a>, <a></a></p>

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -10,7 +10,7 @@ import html2text
 
 
 def test_module(fn, unicode_snob=False, google_doc=False):
-    print_conditions(fn, 'module', unicode_snob, google_doc)
+    print_conditions('module', unicode_snob, google_doc)
 
     h = html2text.HTML2Text()
 
@@ -29,7 +29,7 @@ def test_module(fn, unicode_snob=False, google_doc=False):
 
 
 def test_command(fn, google_doc=False):
-    print_conditions(fn, 'command', False, google_doc)
+    print_conditions('command', False, google_doc)
 
     cmd = ['python', '../html2text.py']
     if fn.lower().startswith('google'):
@@ -48,9 +48,9 @@ def test_command(fn, google_doc=False):
     print_result(fn, 'command', result, actual)
 
 
-def print_conditions(fn, mode, unicode_snob, google_doc):
-    format = "%s (%s, unicode_snob=%d, google_doc=%d): "
-    sys.stdout.write(format % (fn, mode, int(unicode_snob), int(google_doc)))
+def print_conditions(mode, unicode_snob, google_doc):
+    format = " * %s, unicode_snob=%d, google_doc=%d: "
+    sys.stdout.write(format % (mode, int(unicode_snob), int(google_doc)))
 
 
 def print_result(fn, mode, result, actual):
@@ -63,7 +63,10 @@ def print_result(fn, mode, result, actual):
             print(len(result), len(actual))
 
         dump_name = get_dump_name(fn, mode)
-        open(dump_name, 'w').write(result)
+
+        with codecs.open(dump_name, encoding='utf-8', mode='w+') as f:
+            f.write(actual)
+
         print("  Use: diff -u %s %s" % (get_baseline_name(fn), dump_name))
 
 
@@ -90,6 +93,7 @@ def run_all_tests():
         google_doc = fn.lower().startswith('google')
         unicode_snob = fn.lower().find('unicode') > 0
 
+        print('\n' + fn + ':')
         test_module(fn, unicode_snob, google_doc)
 
         if not unicode_snob:

--- a/test/url-escaping.html
+++ b/test/url-escaping.html
@@ -1,0 +1,16 @@
+<h1>Markdown-sensible characters processing</h1>
+
+<p>This test checks special characters processing inside URLs: parenthesis and brackets should be escaped to keep markdown image and anchor syntax safe and sound.</p>
+
+<ul>
+	<li><a nref="http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110)">Some MSDN link using parenthesis.</a></li>
+	<li><a nref="https://www.google.ru/search?q=[brackets are cool]">Google search result URL with unescaped brackets.</a></li>
+	<li><a nref="https://www.google.ru/search?q='[({})]'">Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor.</a></li>
+</ul>
+
+<p>And here are images with tricky attribute values:</p>
+
+<img src="http://placehold.it/350x150#()" width="350" height="150" alt="()"><br>
+<img src="http://placehold.it/350x150#[]" width="350" height="150" alt="[]"><br>
+<img src="http://placehold.it/350x150#{}" width="350" height="150" alt="{}"><br>
+<img src="http://placehold.it/350x150#([{}])" width="350" height="150" alt="([{}])">

--- a/test/url-escaping.html
+++ b/test/url-escaping.html
@@ -3,14 +3,14 @@
 <p>This test checks special characters processing inside URLs: parenthesis and brackets should be escaped to keep markdown image and anchor syntax safe and sound.</p>
 
 <ul>
-	<li><a nref="http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110)">Some MSDN link using parenthesis.</a></li>
-	<li><a nref="https://www.google.ru/search?q=[brackets are cool]">Google search result URL with unescaped brackets.</a></li>
-	<li><a nref="https://www.google.ru/search?q='[({})]'">Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor.</a></li>
+	<li><a href="http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110)">Some MSDN link using parenthesis</a></li>
+	<li><a href="https://www.google.ru/search?q=[brackets are cool]">Google search result URL with unescaped brackets</a></li>
+	<li><a href="https://www.google.ru/search?q='[({})]'">Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor</a></li>
 </ul>
 
 <p>And here are images with tricky attribute values:</p>
 
-<img src="http://placehold.it/350x150#()" width="350" height="150" alt="()"><br>
-<img src="http://placehold.it/350x150#[]" width="350" height="150" alt="[]"><br>
-<img src="http://placehold.it/350x150#{}" width="350" height="150" alt="{}"><br>
+<img src="http://placehold.it/350x150#(banana)" width="350" height="150" alt="(banana)"><br>
+<img src="http://placehold.it/350x150#[banana]" width="350" height="150" alt="[banana]"><br>
+<img src="http://placehold.it/350x150#{banana}" width="350" height="150" alt="{banana}"><br>
 <img src="http://placehold.it/350x150#([{}])" width="350" height="150" alt="([{}])">

--- a/test/url-escaping.md
+++ b/test/url-escaping.md
@@ -1,0 +1,20 @@
+# Markdown-sensible characters processing
+
+This test checks special characters processing inside URLs: parenthesis and
+brackets should be escaped to keep markdown image and anchor syntax safe and
+sound.
+
+  * [Some MSDN link using parenthesis](http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110))
+  * [Google search result URL with unescaped brackets](https://www.google.ru/search?q=[brackets are cool])
+  * [Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor](https://www.google.ru/search?q='[({})]')
+
+And here are images with tricky attribute values:
+
+![(banana)](http://placehold.it/350x150#(banana))
+
+![[banana]](http://placehold.it/350x150#[banana])
+
+![{banana}](http://placehold.it/350x150#{banana})
+
+![([{}])](http://placehold.it/350x150#([{}]))
+

--- a/test/url-escaping.md
+++ b/test/url-escaping.md
@@ -4,17 +4,17 @@ This test checks special characters processing inside URLs: parenthesis and
 brackets should be escaped to keep markdown image and anchor syntax safe and
 sound.
 
-  * [Some MSDN link using parenthesis](http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110))
-  * [Google search result URL with unescaped brackets](https://www.google.ru/search?q=[brackets are cool])
-  * [Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor](https://www.google.ru/search?q='[({})]')
+  * [Some MSDN link using parenthesis](http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d\(v=vs.110\))
+  * [Google search result URL with unescaped brackets](https://www.google.ru/search?q=\[brackets are cool\])
+  * [Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor](https://www.google.ru/search?q='\[\({}\)\]')
 
 And here are images with tricky attribute values:
 
-![(banana)](http://placehold.it/350x150#(banana))
+![\(banana\)](http://placehold.it/350x150#\(banana\))
 
-![[banana]](http://placehold.it/350x150#[banana])
+![\[banana\]](http://placehold.it/350x150#\[banana\])
 
 ![{banana}](http://placehold.it/350x150#{banana})
 
-![([{}])](http://placehold.it/350x150#([{}]))
+![\(\[{}\]\)](http://placehold.it/350x150#\(\[{}\]\))
 


### PR DESCRIPTION
I found another bug: URLs containing unencoded brackets and parenthesis could break markdown links and images syntax when INLINE_LINKS = True. For example the following code:

```
<a href="http://example.com/;-)/page.html">...</a>
```

will be transformed to

```
[...](http://example.com/;-)/page.html)
```

which will give the following MD transformation result (tested with python-markdown and dillinger.io):

```
<a href="http://example.com/;-">...</a>)/page.html
```

The same problem could appear with image source values. This case is not very common but some sites (e.g. MSDN) actively uses parenthesis in URLs.

I've fixed this by escaping parenthesis and brackets, so the result will produce correct HTML:

```
 [...](http://example.com/;-\)/page.html)
```

This patch includes bugfix and new test case for URL escaping.
