### PR TITLE
Avoid IndexError when handling a paragraph that is just "--"

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -729,7 +729,7 @@ def skipwrap(para):
     # If the text begins with only two "--", possibly preceded by whitespace, that's
     # an emdash; so wrap.
     stripped = para.lstrip()
-    if stripped[0:2] == "--" and stripped[2] != "-":
+    if stripped[0:2] == "--" and len(stripped) > 2 and stripped[2] != "-":
         return False
     # I'm not sure what this is for; I thought it was to detect lists, but there's
     # a <br>-inside-<span> case in one of the tests that also depends upon it.

--- a/test/emdash-para.html
+++ b/test/emdash-para.html
@@ -1,3 +1,4 @@
 <p>Bacon ipsum dolor sit amet pork chop id pork belly ham hock, sed meatloaf eu exercitation flank quis veniam officia. Chuck dolor esse, occaecat est elit drumstick ground round tri-tip nisi. Eu fugiat drumstick leberkas magna. Turducken frankfurter nisi aute shank&mdash;</p>
 <p>&mdash;irure ex esse id, ham commodo meatloaf pig pariatur ut cow. Officia salami in fatback voluptate boudin ullamco beef ribs shank. Duis spare ribs pork chop, ad leberkas reprehenderit id voluptate salami ham ut in ut cillum turducken. Nisi ribeye tail capicola dolore andouille. Short ribs id beef ribs, et nulla ground round do sunt dolore. Dolore nisi ullamco veniam sunt. Duis brisket drumstick, dolor fatback filet mignon meatloaf laboris tri-tip speck chuck ball tip voluptate ullamco laborum.
 </p>
+<p>--</p>

--- a/test/emdash-para.md
+++ b/test/emdash-para.md
@@ -11,3 +11,5 @@ ribs, et nulla ground round do sunt dolore. Dolore nisi ullamco veniam sunt.
 Duis brisket drumstick, dolor fatback filet mignon meatloaf laboris tri-tip
 speck chuck ball tip voluptate ullamco laborum.
 
+--
+


### PR DESCRIPTION
I am not 100% sure this should return False in this case, since I'm not very familiar with the skipwrap function, but this at least avoids the exception from being raised.
