### PR TITLE
Support automatic links

### DIFF
--- a/test/url-escaping.html
+++ b/test/url-escaping.html
@@ -6,6 +6,8 @@
 	<li><a href="http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d(v=vs.110)">Some MSDN link using parenthesis</a></li>
 	<li><a href="https://www.google.ru/search?q=[brackets are cool]">Google search result URL with unescaped brackets</a></li>
 	<li><a href="https://www.google.ru/search?q='[({})]'">Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor</a></li>
+	<li>Use automatic links like <a href="http://example.com/">http://example.com/</a> when the URL is the label</a>
+	<li>Exempt <a href="non-absolute_URIs">non-absolute_URIs</a> from automatic link detection</a>
 </ul>
 
 <p>And here are images with tricky attribute values:</p>

--- a/test/url-escaping.md
+++ b/test/url-escaping.md
@@ -7,6 +7,8 @@ sound.
   * [Some MSDN link using parenthesis](http://msdn.microsoft.com/en-us/library/system.drawing.drawing2d\(v=vs.110\))
   * [Google search result URL with unescaped brackets](https://www.google.ru/search?q=\[brackets are cool\])
   * [Yet another test for [brackets], {curly braces} and (parenthesis) processing inside the anchor](https://www.google.ru/search?q='\[\({}\)\]')
+  * Use automatic links like <http://example.com/> when the URL is the label
+  * Exempt [non-absolute_URIs](non-absolute_URIs) from automatic link detection
 
 And here are images with tricky attribute values:
 


### PR DESCRIPTION
Converting links that use the URL as their label to `[http://URL](http://URL)` is ugly. This patch makes them come out as `<http://URL>` instead.
