### PR TITLE
Proper escaping for -+.\

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -663,8 +663,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                 self.o("[")
                 self.maybe_automatic_link = None
 
-        if self.escape_snob and not self.code and not self.pre:
-            data = escape_md(data, snob=True)
+        if not self.code and not self.pre:
+            data = escape_md_section(data, snob=self.escape_snob)
         self.o(data, 1)
 
     def unknown_decl(self, data): pass
@@ -744,7 +744,26 @@ class HTML2Text(HTMLParser.HTMLParser):
 ordered_list_matcher = re.compile(r'\d+\.\s')
 unordered_list_matcher = re.compile(r'[-\*\+]\s')
 md_chars_matcher = re.compile(r"([\\\[\]\(\)])")
-md_chars_matcher_all = re.compile(r"([\\`\*_{}\[\]\(\)#\+\-\.!])")
+md_chars_matcher_all = re.compile(r"([\\`\*_{}\[\]\(\)#!])")
+md_dot_matcher = re.compile(r"""
+    ^             # start of line
+    (\s*\d+)      # optional whitespace and a number
+    (\.)          # dot
+    (?=\s)        # lookahead assert whitespace
+    """, re.MULTILINE | re.VERBOSE)
+md_plus_matcher = re.compile(r"""
+    ^
+    (\s*)
+    (\+)
+    (?=\s)
+    """, flags=re.MULTILINE | re.VERBOSE)
+md_dash_matcher = re.compile(r"""
+    ^
+    (\s*)
+    (-)
+    (?=\s|\-)     # followed by whitespace (bullet list, or spaced out hr)
+                  # or another dash (header or hr)
+    """, flags=re.MULTILINE | re.VERBOSE)
 
 def skipwrap(para):
     # If the text begins with four spaces or one tab, it's a code block; don't wrap
@@ -782,10 +801,19 @@ def unescape(s, unicode_snob=False):
     h.unicode_snob = unicode_snob
     return h.unescape(s)
 
-def escape_md(text, snob=False):
-    """Escapes markdown-sensitive characters."""
-    matcher = md_chars_matcher_all if snob else md_chars_matcher
-    return matcher.sub(r"\\\1", text)
+def escape_md(text):
+    """Escapes markdown-sensitive characters within other markdown constructs."""
+    return md_chars_matcher.sub(r"\\\1", text)
+
+def escape_md_section(text, snob=False):
+    """Escapes markdown-sensitive characters across whole document sections."""
+    if snob:
+        text = md_chars_matcher_all.sub(r"\\\1", text)
+    text = md_dot_matcher.sub(r"\1\\\2", text)
+    text = md_plus_matcher.sub(r"\1\\\2", text)
+    text = md_dash_matcher.sub(r"\1\\\2", text)
+    return text
+
 
 def main():
     baseurl = ''

--- a/html2text.py
+++ b/html2text.py
@@ -744,7 +744,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 ordered_list_matcher = re.compile(r'\d+\.\s')
 unordered_list_matcher = re.compile(r'[-\*\+]\s')
 md_chars_matcher = re.compile(r"([\\\[\]\(\)])")
-md_chars_matcher_all = re.compile(r"([\\`\*_{}\[\]\(\)#!])")
+md_chars_matcher_all = re.compile(r"([`\*_{}\[\]\(\)#!])")
 md_dot_matcher = re.compile(r"""
     ^             # start of line
     (\s*\d+)      # optional whitespace and a number
@@ -764,6 +764,12 @@ md_dash_matcher = re.compile(r"""
     (?=\s|\-)     # followed by whitespace (bullet list, or spaced out hr)
                   # or another dash (header or hr)
     """, flags=re.MULTILINE | re.VERBOSE)
+slash_chars = r'\`*_{}[]()#+-.!'
+md_backslash_matcher = re.compile(r'''
+    (\\)          # match one slash
+    (?=[%s])      # followed by a char that requires escaping
+    ''' % re.escape(slash_chars),
+    flags=re.VERBOSE)
 
 def skipwrap(para):
     # If the text begins with four spaces or one tab, it's a code block; don't wrap
@@ -807,6 +813,7 @@ def escape_md(text):
 
 def escape_md_section(text, snob=False):
     """Escapes markdown-sensitive characters across whole document sections."""
+    text = md_backslash_matcher.sub(r"\\\1", text)
     if snob:
         text = md_chars_matcher_all.sub(r"\\\1", text)
     text = md_dot_matcher.sub(r"\1\\\2", text)

--- a/test/emdash-para.md
+++ b/test/emdash-para.md
@@ -11,5 +11,5 @@ ribs, et nulla ground round do sunt dolore. Dolore nisi ullamco veniam sunt.
 Duis brisket drumstick, dolor fatback filet mignon meatloaf laboris tri-tip
 speck chuck ball tip voluptate ullamco laborum.
 
---
+\--
 

--- a/test/normal.html
+++ b/test/normal.html
@@ -96,6 +96,41 @@ def func(x):
 //]]>
 </script>
 
+    <p>
+        2012. Now that was a good year. So was 2011. That's all.
+    </p>
+
+    <p>
+        3.14159 is an approximation of pi.
+    </p>
+
+    <p>
+        + not + a list item
+    </p>
+
+    <p>
+        +foo
+    </p>
+
+    <p>
+        - foo - bar
+    </p>
+
+    <p>
+        -foo
+    </p>
+
+    <p>
+        not a header<br>
+        --
+    </p>
+
+    <p>
+        not a hr<br>
+        <br>
+        ---
+        <br>
+        - - -
+    </p>
   </body>
 </html>
-

--- a/test/normal.html
+++ b/test/normal.html
@@ -132,5 +132,9 @@ def func(x):
         <br>
         - - -
     </p>
+
+    <p>
+        c:\tmp, \\server\path, \_/, foo\bar, #\#, \\#
+    </p>
   </body>
 </html>

--- a/test/normal.md
+++ b/test/normal.md
@@ -30,3 +30,23 @@ _italic_
 Some `fixed width text` here  
 _`italic fixed width text`_
 
+2012\. Now that was a good year. So was 2011. That's all.
+
+3.14159 is an approximation of pi.
+
+\+ not + a list item
+
++foo
+
+\- foo - bar
+
+-foo 
+
+not a header  
+\--
+
+not a hr  
+  
+\---  
+\- - -
+

--- a/test/normal.md
+++ b/test/normal.md
@@ -50,3 +50,5 @@ not a hr
 \---  
 \- - -
 
+c:\tmp, \\\server\path, \\_/, foo\bar, #\\#, \\\\#
+

--- a/test/normal_escape_snob.html
+++ b/test/normal_escape_snob.html
@@ -100,6 +100,41 @@ def func(x):
 //]]>
 </script>
 
+    <p>
+        2012. Now that was a good year. So was 2011. That's all.
+    </p>
+
+    <p>
+        3.14159 is an approximation of pi.
+    </p>
+
+    <p>
+        + not + a list item
+    </p>
+
+    <p>
+        +foo
+    </p>
+
+    <p>
+        - foo - bar
+    </p>
+
+    <p>
+        -foo
+    </p>
+
+    <p>
+        not a header<br>
+        --
+    </p>
+
+    <p>
+        not a hr<br>
+        <br>
+        ---
+        <br>
+        - - -
+    </p>
   </body>
 </html>
-

--- a/test/normal_escape_snob.html
+++ b/test/normal_escape_snob.html
@@ -28,9 +28,6 @@
         <li>
           <span>apple</span>
         </li>
-        <li>
-          <span>yam\\sweet potato</span>
-        </li>
       </ul>
       <li>
         <span>final</span>
@@ -135,6 +132,10 @@ def func(x):
         ---
         <br>
         - - -
+    </p>
+    
+    <p>
+        c:\tmp, \\server\path, \_/, foo\bar, #\#, \\#
     </p>
   </body>
 </html>

--- a/test/normal_escape_snob.md
+++ b/test/normal_escape_snob.md
@@ -6,7 +6,6 @@ first issue
   * _**bold italic**_
     * orange
     * apple
-    * yam\\\\sweet potato
   * final
 
 text to separate lists
@@ -51,4 +50,6 @@ not a hr
   
 \---  
 \- - -
+
+c:\tmp, \\\server\path, \\\_/, foo\bar, \#\\\#, \\\\\#
 

--- a/test/normal_escape_snob.md
+++ b/test/normal_escape_snob.md
@@ -32,3 +32,23 @@ text with \_underscore but not \_italicized
 Some `fixed width text` here  
 _`italic fixed width text`_
 
+2012\. Now that was a good year. So was 2011. That's all.
+
+3.14159 is an approximation of pi.
+
+\+ not + a list item
+
++foo
+
+\- foo - bar
+
+-foo 
+
+not a header  
+\--
+
+not a hr  
+  
+\---  
+\- - -
+


### PR DESCRIPTION
This moves eager escaping for chars -+.\ out of the "escape_snob" option and into the default mode, with care to only escape them when needed.
