### PR TITLE
Add semicolon to style data for safety

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -110,6 +110,7 @@ def dumb_property_dict(style):
 def dumb_css_parser(data):
     """returns a hash of css selectors, each of which contains a hash of css attributes"""
     # remove @import sentences
+    data += ';'
     importIndex = data.find('@import')
     while importIndex != -1:
         data = data[0:importIndex] + data[data.find(';', importIndex) + 1:]


### PR DESCRIPTION
If the style data does not contain a semicolon, the loop removing @import
statements will run infinitely, because the search for ';' returns -1, which
with a +1 becomes 0, and appends the data variable to itself. Making sure the
data variable has at least one semicolon fixes this problem.
