### PR TITLE
Handle HTML with invalid "start" attribute for ol elements

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -174,9 +174,12 @@ def google_fixed_width_font(style):
 def list_numbering_start(attrs):
     """extract numbering from list element attributes"""
     if 'start' in attrs:
-        return int(attrs['start']) - 1
-    else:
-        return 0
+        try:
+            return int(attrs['start']) - 1
+        except ValueError:
+            pass
+
+    return 0
 
 class HTML2Text(HTMLParser.HTMLParser):
     def __init__(self, out=None, baseurl=''):

--- a/test/invalid_start.html
+++ b/test/invalid_start.html
@@ -1,0 +1,8 @@
+<html>
+   <body>
+      <ol start="invalid">
+         <li>The ol has an invalid start </li>
+         <li>This should just be ignored </li>
+      </ol>
+   </body>
+</html>

--- a/test/invalid_start.md
+++ b/test/invalid_start.md
@@ -1,0 +1,3 @@
+  1. The ol has an invalid start 
+  2. This should just be ignored 
+


### PR DESCRIPTION
This simply catches the value error for the int cast, and returns the default value. Added a simple testcase also.
