### PR TITLE
Add python 3.3 to supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.0',
        'Programming Language :: Python :: 3.1',
-       'Programming Language :: Python :: 3.2'
+       'Programming Language :: Python :: 3.2',
+       'Programming Language :: Python :: 3.3',
      ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
However maybe the untested versions should be removed, like 2.3, 2.4, and 3.0, 3.1
