### PR TITLE
Add ".py" suffix to html2text entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
      ],
     entry_points="""
         [console_scripts]
-        html2text=html2text:main
+        html2text.py=html2text:main
     """,
    license='GNU GPL 3',
    packages=find_packages(),


### PR DESCRIPTION
Many distributions (including Gentoo and openSUSE) already ship
/usr/bin/html2text as part of the "html2text" package. Therefore the
current entry point collides with this system binary. Adding a .py
prefix would mean it's installed as /usr/bin/html2text.py which is just
working fine.

Fixes #42
