### PR TITLE
Make html2text.py compatible with python 3.*

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """html2text: Turn HTML into equivalent Markdown-structured text."""
+from __future__ import division
 __version__ = "3.200.3"
 __author__ = "Aaron Swartz (me@aaronsw.com)"
 __copyright__ = "(C) 2004-2008 Aaron Swartz. GNU GPL 3."
@@ -62,15 +63,13 @@ IGNORE_IMAGES = False
 IGNORE_EMPHASIS = False
 
 ### Entity Nonsense ###
+# For checking space-only lines on line 771
+SPACE_RE = re.compile(r'\s\+')
 
 def name2cp(k):
     if k == 'apos': return ord("'")
-    if hasattr(htmlentitydefs, "name2codepoint"): # requires Python 2.3
-        return htmlentitydefs.name2codepoint[k]
-    else:
-        k = htmlentitydefs.entitydefs[k]
-        if k.startswith("&#") and k.endswith(";"): return int(k[2:-1]) # not in latin-1
-        return ord(codecs.latin_1_decode(k)[0])
+    return htmlentitydefs.name2codepoint[k]
+
 
 unifiable = {'rsquo':"'", 'lsquo':"'", 'rdquo':'"', 'ldquo':'"',
 'copy':'(C)', 'mdash':'--', 'nbsp':' ', 'rarr':'->', 'larr':'<-', 'middot':'*',
@@ -88,14 +87,6 @@ for k in unifiable.keys():
     unifiable_n[name2cp(k)] = unifiable[k]
 
 ### End Entity Nonsense ###
-
-def onlywhite(line):
-    """Return true if the line does only consist of whitespace characters."""
-    for c in line:
-        if c is not ' ' and c is not '  ':
-            return c is ' '
-    return line
-
 def hn(tag):
     if tag[0] == 'h' and len(tag) == 2:
         try:
@@ -105,7 +96,10 @@ def hn(tag):
 
 def dumb_property_dict(style):
     """returns a hash of css attributes"""
-    return dict([(x.strip(), y.strip()) for x, y in [z.split(':', 1) for z in style.split(';') if ':' in z]]);
+    out = dict([(x.strip(), y.strip()) for x, y in
+        [z.split(':', 1) for z in
+            style.split(';') if ':' in z]]);
+    return out
 
 def dumb_css_parser(data):
     """returns a hash of css selectors, each of which contains a hash of css attributes"""
@@ -265,10 +259,19 @@ class HTML2Text(HTMLParser.HTMLParser):
 
         self.outtext = self.outtext.join(self.outtextlist)
         if self.unicode_snob:
-            nbsp = unichr(name2cp('nbsp'))
+            try:
+                nbsp = unichr(name2cp('nbsp'))
+            except NameError:
+                nbsp = chr(name2cp('nbsp'))
         else:
-            nbsp = u' '
-        self.outtext = self.outtext.replace(u'&nbsp_place_holder;', nbsp)
+            try:
+                nbsp = unichr(32)
+            except NameError:
+                nbsp = chr(32)
+        try:
+            self.outtext = self.outtext.replace(unicode('&nbsp_place_holder;'), nbsp)
+        except NameError:
+            self.outtext = self.outtext.replace('&nbsp_place_holder;', nbsp)
 
         return self.outtext
 
@@ -376,6 +379,7 @@ class HTML2Text(HTMLParser.HTMLParser):
 
     def handle_tag(self, tag, attrs, start):
         #attrs = fixattrs(attrs)
+        # attrs is None for endtags
         if attrs is None:
             attrs = {}
         else:
@@ -578,7 +582,8 @@ class HTML2Text(HTMLParser.HTMLParser):
 
         if not self.quiet:
             if self.google_doc:
-                # prevent white space immediately after 'begin emphasis' marks ('**' and '_')
+                # prevent white space immediately after 'begin emphasis'
+                # marks ('**' and '_')
                 lstripped_data = data.lstrip()
                 if self.drop_white_space and not (self.pre or self.code):
                     data = lstripped_data
@@ -586,7 +591,10 @@ class HTML2Text(HTMLParser.HTMLParser):
                     self.drop_white_space = 0
 
             if puredata and not self.pre:
-                data = re.sub('\s+', ' ', data)
+                # This is a very dangerous call ... it could mess up
+                # all handling of &nbsp; when not handled properly
+                # (see entityref)
+                data = re.sub(r'\s+', r' ', data)
                 if data and data[0] == ' ':
                     self.space = 1
                     data = data[1:]
@@ -598,13 +606,14 @@ class HTML2Text(HTMLParser.HTMLParser):
                     data = "\n" + data
 
             bq = (">" * self.blockquote)
-            if not (force and data and data[0] == ">") and self.blockquote: bq += " "
+            if not (force and data and data[0] == ">") and self.blockquote:
+                bq += " "
 
             if self.pre:
                 if not self.list:
                     bq += "    "
                 #else: list content is already partially indented
-                for i in xrange(len(self.list)):
+                for i in range(len(self.list)):
                     bq += "    "
                 data = data.replace("\n", "\n"+bq)
 
@@ -633,19 +642,24 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if not self.lastWasNL: self.out(' ')
                 self.space = 0
 
-            if self.a and ((self.p_p == 2 and self.links_each_paragraph) or force == "end"):
+            if self.a and ((self.p_p == 2 and self.links_each_paragraph)
+                    or force == "end"):
                 if force == "end": self.out("\n")
 
                 newa = []
                 for link in self.a:
                     if self.outcount > link['outcount']:
-                        self.out("   ["+ str(link['count']) +"]: " + urlparse.urljoin(self.baseurl, link['href']))
-                        if has_key(link, 'title'): self.out(" ("+link['title']+")")
+                        self.out("   ["+ str(link['count']) +"]: " +
+                            urlparse.urljoin(self.baseurl, link['href']))
+                        if 'title' in link:
+                            self.out(" ("+link['title']+")")
                         self.out("\n")
                     else:
                         newa.append(link)
 
-                if self.a != newa: self.out("\n") # Don't need an extra line when nothing was done.
+                # Don't need an extra line when nothing was done.
+                if self.a != newa:
+                    self.out("\n")
 
                 self.a = newa
 
@@ -699,10 +713,13 @@ class HTML2Text(HTMLParser.HTMLParser):
             try: name2cp(c)
             except KeyError: return "&" + c + ';'
             else:
-                try:
-                    return unichr(name2cp(c))
-                except NameError: #Python3
-                    return chr(name2cp(c))
+                if c == 'nbsp':
+                    return unifiable[c]
+                else:
+                    try:
+                        return unichr(name2cp(c))
+                    except NameError: #Python3
+                        return chr(name2cp(c))
 
     def replaceEntities(self, s):
         s = s.group(1)
@@ -718,7 +735,7 @@ class HTML2Text(HTMLParser.HTMLParser):
         """calculate the nesting count of google doc lists"""
         nest_count = 0
         if 'margin-left' in style:
-            nest_count = int(style['margin-left'][:-2]) / self.google_list_indent
+            nest_count = int(style['margin-left'][:-2]) // self.google_list_indent
         return nest_count
 
 
@@ -741,7 +758,11 @@ class HTML2Text(HTMLParser.HTMLParser):
                         result += "\n\n"
                         newlines = 2
                 else:
-                    if not onlywhite(para):
+                    # Warning for the tempted!!!
+                    # Be aware that obvious replacement of this with
+                    # line.isspace()
+                    # DOES NOT work! Explanations are welcome.
+                    if not SPACE_RE.match(para):
                         result += para + "\n"
                         newlines = 1
             else:

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -20,11 +20,11 @@ def test_module(fn, google_doc=False, **kwargs):
         h.body_width = 0
         h.hide_strikethrough = True
 
-    for k, v in kwargs.iteritems():
+    for k, v in kwargs.items():
         setattr(h, k, v)
 
     result = get_baseline(fn)
-    actual = h.handle(file(fn).read())
+    actual = h.handle(open(fn).read())
     return print_result(fn, 'module', result, actual)
 
 def test_command(fn, *args):
@@ -51,7 +51,7 @@ def test_command(fn, *args):
         actual = re.sub(r'\r+', '\r', actual)
         actual = actual.replace('\r\n', '\n')
 
-    return print_result(fn, 'command', result, actual)
+    return print_result(fn, 'command', result, actual.decode('utf8'))
 
 def print_conditions(mode, *args, **kwargs):
     format = " * %s %s, %s: "
@@ -70,7 +70,7 @@ def print_result(fn, mode, result, actual):
         dump_name = get_dump_name(fn, mode)
 
         f = codecs.open(dump_name, encoding='utf-8', mode='w+')
-        f.write(actual)
+        f.write(actual.decode('utf8'))
 
         print("  Use: diff -u %s %s" % (get_baseline_name(fn), dump_name))
         return False


### PR DESCRIPTION
- Don't expect u'' strings to work.
- Fix nbsp_unicode test.
- Also remove workaround for python < 2.3 ... we really don’t need it
  anymore.
- Fix <pre> in list tests.
  Replace onlywhite function with RE.
  
  I believe that Aaron by mistake put to the html2text.py his
  contribution to the Obfuscated Python Code Contest.
  
  For the reasons I have no chance to decipher, I have to use RE.
  More obvious replacement with para.isspace() doesn't work.

Signed-off-by: Matěj Cepl mcepl@redhat.com
