### PR TITLE
Added additional HTML entities for ascii conversion.

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -80,7 +80,9 @@ unifiable = {'rsquo':"'", 'lsquo':"'", 'rdquo':'"', 'ldquo':'"',
 'igrave':'i', 'iacute':'i', 'icirc':'i', 'iuml':'i',
 'ograve':'o', 'oacute':'o', 'ocirc':'o', 'otilde':'o', 'ouml':'o',
 'ugrave':'u', 'uacute':'u', 'ucirc':'u', 'uuml':'u',
-'lrm':'', 'rlm':''}
+'lrm':'', 'rlm':'',
+'laquo': '<<', 'raquo': '>>', 'lsaquo': '<', 'rsaquo': '>',
+'reg': '(R)', 'trade': '(TM)', 'bull': '*'}
 
 unifiable_n = {}
 


### PR DESCRIPTION
I was running into a `UnicodeEncodeError` trying to save an ascii file created by html2text. Turns out there were a few valid HTML entities we were using that were not being converted properly. This small commit adds those missing entities.

Thanks for taking a look.
