### PR TITLE
Remove noop onlywhite function.

### DIFF
--- a/html2text.py
+++ b/html2text.py
@@ -89,13 +89,6 @@ for k in unifiable.keys():
 
 ### End Entity Nonsense ###
 
-def onlywhite(line):
-    """Return true if the line does only consist of whitespace characters."""
-    for c in line:
-        if c is not ' ' and c is not '  ':
-            return c is ' '
-    return line
-
 def hn(tag):
     if tag[0] == 'h' and len(tag) == 2:
         try:
@@ -741,9 +734,8 @@ class HTML2Text(HTMLParser.HTMLParser):
                         result += "\n\n"
                         newlines = 2
                 else:
-                    if not onlywhite(para):
-                        result += para + "\n"
-                        newlines = 1
+                    result += para + "\n"
+                    newlines = 1
             else:
                 if newlines < 2:
                     result += "\n"


### PR DESCRIPTION
`onlywhite` was always returning `False` because referential comparison between `text` and `bytes` is always `False`
